### PR TITLE
feat: :tada: unify drink customization with flavors and sizes

### DIFF
--- a/src/actions/products/get-products.ts
+++ b/src/actions/products/get-products.ts
@@ -3171,11 +3171,111 @@ export async function getProducts(): Promise<Product[]> {
     },
 
     // REFRESCOS
-    // refresco natural (ingredients)
+    // Refresco natural (limited ingredients)
     {
       id: randomUUID(),
       productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Horchata 500ml',
+      name: 'Horchata',
+      price: 0,
+      quantity: 0,
+      isAvailable: true,
+      type: 'limited-ingredient'
+    },
+    {
+      id: randomUUID(),
+      productId: products.find(p => p.name === 'Refresco natural')!.id,
+      name: 'Jamaica',
+      price: 0,
+      quantity: 0,
+      isAvailable: true,
+      type: 'limited-ingredient'
+    },
+    {
+      id: randomUUID(),
+      productId: products.find(p => p.name === 'Refresco natural')!.id,
+      name: 'Limonada',
+      price: 0,
+      quantity: 0,
+      isAvailable: true,
+      type: 'limited-ingredient'
+    },
+    {
+      id: randomUUID(),
+      productId: products.find(p => p.name === 'Refresco natural')!.id,
+      name: 'Limonada fresa',
+      price: 0,
+      quantity: 0,
+      isAvailable: true,
+      type: 'limited-ingredient'
+    },
+    {
+      id: randomUUID(),
+      productId: products.find(p => p.name === 'Refresco natural')!.id,
+      name: 'Pepino limón',
+      price: 0,
+      quantity: 0,
+      isAvailable: true,
+      type: 'limited-ingredient'
+    },
+    {
+      id: randomUUID(),
+      productId: products.find(p => p.name === 'Refresco natural')!.id,
+      name: 'Chaya Piña (solo en temporada)',
+      price: 0,
+      quantity: 0,
+      isAvailable: true,
+      type: 'limited-ingredient'
+    },
+    {
+      id: randomUUID(),
+      productId: products.find(p => p.name === 'Refresco natural')!.id,
+      name: 'Piña (solo en temporada)',
+      price: 0,
+      quantity: 0,
+      isAvailable: true,
+      type: 'limited-ingredient'
+    },
+    {
+      id: randomUUID(),
+      productId: products.find(p => p.name === 'Refresco natural')!.id,
+      name: 'Lima (solo en temporada)',
+      price: 0,
+      quantity: 0,
+      isAvailable: true,
+      type: 'limited-ingredient'
+    },
+    {
+      id: randomUUID(),
+      productId: products.find(p => p.name === 'Refresco natural')!.id,
+      name: 'Mandarina (solo en temporada)',
+      price: 0,
+      quantity: 0,
+      isAvailable: true,
+      type: 'limited-ingredient'
+    },
+    {
+      id: randomUUID(),
+      productId: products.find(p => p.name === 'Refresco natural')!.id,
+      name: 'Pitalla (solo en temporada)',
+      price: 0,
+      quantity: 0,
+      isAvailable: true,
+      type: 'limited-ingredient'
+    },
+    {
+      id: randomUUID(),
+      productId: products.find(p => p.name === 'Refresco natural')!.id,
+      name: 'Marañon (solo en temporada)',
+      price: 0,
+      quantity: 0,
+      isAvailable: true,
+      type: 'limited-ingredient'
+    },
+    // Refresco natural (sizes)
+    {
+      id: randomUUID(),
+      productId: products.find(p => p.name === 'Refresco natural')!.id,
+      name: '500 ml',
       price: 25,
       quantity: 0,
       isAvailable: true,
@@ -3184,187 +3284,45 @@ export async function getProducts(): Promise<Product[]> {
     {
       id: randomUUID(),
       productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Horchata 1lt',
+      name: '1 lt',
       price: 42,
       quantity: 0,
       isAvailable: true,
       type: 'size'
     },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Jamaica 500ml',
-      price: 25,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Jamaica 1lt',
-      price: 42,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Limonada fresa 500 ml',
-      price: 25,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Limonada fresa 1 lt',
-      price: 42,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Pepino limón 500ml',
-      price: 25,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Pepino limón 1 lt',
-      price: 42,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Chaya Piña 500ml (solo en temporada)',
-      price: 25,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Chaya Piña 1 lt (solo en temporada)',
-      price: 42,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Piña 500ml (solo en temporada)',
-      price: 25,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Piña 1 lt (solo en temporada)',
-      price: 42,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Lima 500ml (solo en temporada)',
-      price: 25,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Mandarina 500ml (solo en temporada)',
-      price: 25,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Mandarina 1 lt (solo en temporada)',
-      price: 42,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Pitalla 500 ml (solo en temporada)',
-      price: 25,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Pitalla 1 lt (solo en temporada)',
-      price: 42,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Marañon 500ml (solo en temporada)',
-      price: 25,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Refresco natural')!.id,
-      name: 'Marañon 1 lt (solo en temporada)',
-      price: 42,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
+    // Peñafiel (limited ingredients)
     {
       id: randomUUID(),
       productId: products.find(p => p.name === 'Peñafiel')!.id,
       name: 'Fresa',
-      price: 32,
+      price: 0,
       quantity: 0,
       isAvailable: true,
-      type: 'size'
+      type: 'limited-ingredient'
     },
     {
       id: randomUUID(),
       productId: products.find(p => p.name === 'Peñafiel')!.id,
       name: 'Manzana',
-      price: 32,
+      price: 0,
       quantity: 0,
       isAvailable: true,
-      type: 'size'
+      type: 'limited-ingredient'
     },
     {
       id: randomUUID(),
       productId: products.find(p => p.name === 'Peñafiel')!.id,
       name: 'Agua mineral',
+      price: 0,
+      quantity: 0,
+      isAvailable: true,
+      type: 'limited-ingredient'
+    },
+    // Peñafiel (sizes)
+    {
+      id: randomUUID(),
+      productId: products.find(p => p.name === 'Peñafiel')!.id,
+      name: '600 ml',
       price: 32,
       quantity: 0,
       isAvailable: true,
@@ -3374,34 +3332,44 @@ export async function getProducts(): Promise<Product[]> {
     {
       id: randomUUID(),
       productId: products.find(p => p.name === 'Té Reca')!.id,
-      name: 'Original 500ml',
-      price: 25,
+      name: 'Original',
+      price: 0,
       quantity: 0,
       isAvailable: true,
-      type: 'size'
+      type: 'limited-ingredient'
     },
     {
       id: randomUUID(),
       productId: products.find(p => p.name === 'Té Reca')!.id,
-      name: 'Original ligero 500ml',
-      price: 25,
+      name: 'Original ligero',
+      price: 0,
       quantity: 0,
       isAvailable: true,
-      type: 'size'
+      type: 'limited-ingredient'
     },
     {
       id: randomUUID(),
       productId: products.find(p => p.name === 'Té Reca')!.id,
-      name: 'Con limón 500ml',
-      price: 25,
+      name: 'Con limón',
+      price: 0,
       quantity: 0,
       isAvailable: true,
-      type: 'size'
+      type: 'limited-ingredient'
     },
     {
       id: randomUUID(),
       productId: products.find(p => p.name === 'Té Reca')!.id,
       name: 'Verde',
+      price: 0,
+      quantity: 0,
+      isAvailable: true,
+      type: 'limited-ingredient'
+    },
+    // Té Reca (sizes)
+    {
+      id: randomUUID(),
+      productId: products.find(p => p.name === 'Té Reca')!.id,
+      name: '500 ml',
       price: 25,
       quantity: 0,
       isAvailable: true,
@@ -3410,16 +3378,7 @@ export async function getProducts(): Promise<Product[]> {
     {
       id: randomUUID(),
       productId: products.find(p => p.name === 'Té Reca')!.id,
-      name: 'Original 1lt',
-      price: 42,
-      quantity: 0,
-      isAvailable: true,
-      type: 'size'
-    },
-    {
-      id: randomUUID(),
-      productId: products.find(p => p.name === 'Té Reca')!.id,
-      name: 'Con limón 1lt',
+      name: '1 lt',
       price: 42,
       quantity: 0,
       isAvailable: true,

--- a/src/components/products/product-options-limited.tsx
+++ b/src/components/products/product-options-limited.tsx
@@ -4,25 +4,30 @@ import { motion } from 'framer-motion'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
 import { type ProductOption } from '@/lib/types'
+import { isRefrescoNatural } from '@/lib/utils'
 
 interface ProductOptionsLimitedProps {
   options: ProductOption[]
   selectedOptionIds: string[]
   setSelectedOptionIds: React.Dispatch<React.SetStateAction<string[]>>
   maxSelected: number
+  productName: string
 }
 
 export const ProductOptionsLimited = ({
   options,
   selectedOptionIds,
   setSelectedOptionIds,
-  maxSelected
+  maxSelected,
+  productName
 }: ProductOptionsLimitedProps) => {
+  const internalMaxSelected = isRefrescoNatural(productName) ? 1 : maxSelected
+
   const handleOptionToggle = (optionId: string) => {
     setSelectedOptionIds((prev) => {
       if (prev.includes(optionId)) {
         return prev.filter((id) => id !== optionId)
-      } else if (prev.length < maxSelected) {
+      } else if (prev.length < internalMaxSelected) {
         return [...prev, optionId]
       } else {
         return prev
@@ -30,12 +35,12 @@ export const ProductOptionsLimited = ({
     })
   }
 
-  const isMaxReached = selectedOptionIds.length >= maxSelected
+  const isMaxReached = selectedOptionIds.length >= internalMaxSelected
 
   return (
     <div className="space-y-4">
       <div>
-        <h4 className="font-medium mb-3">Elige hasta 3 guisos:</h4>
+        <h4 className="font-medium mb-3">{isRefrescoNatural(productName) ? 'Elige un sabor' : 'Elige hasta 3 guisos'}:</h4>
         <div className="space-y-1">
           {options?.map((option) => {
             const isSelected = selectedOptionIds.includes(option.id || '')
@@ -65,9 +70,13 @@ export const ProductOptionsLimited = ({
                 >
                   <div className="flex justify-between items-center">
                     <span className="font-medium">{option.name}</span>
-                    <span className="text-muted-foreground">
-                      {option.price > 0 ? `+$${option.price.toFixed(2)}` : 'Incluido'}
-                    </span>
+                    {
+                      !isRefrescoNatural && (
+                        <span className="text-muted-foreground">
+                          {option.price > 0 ? `+$${option.price.toFixed(2)}` : 'Incluido'}
+                        </span>
+                      )
+                    }
                   </div>
                 </Label>
                 {!option.isAvailable && (

--- a/src/components/products/product-options-modal.tsx
+++ b/src/components/products/product-options-modal.tsx
@@ -37,12 +37,6 @@ export default function ProductOptionsModal({ product, isOpen, onClose }: Produc
 
   const handleAddToCart = () => {
     if (!isReadyToAdd) return
-    // const hasSomethingSelected =
-    //   isVariableOnly ||
-    //   isFreeSelectionOnly ||
-    //   (!!selectedOption || selectedLimitedOptions.length > 0)
-
-    // if (!hasSomethingSelected) return
 
     const noteOptionDefaultValues = {
       id: crypto.randomUUID(),
@@ -100,33 +94,17 @@ export default function ProductOptionsModal({ product, isOpen, onClose }: Produc
   }
 
   const sizeOptions = product.groupedOptions?.size || []
-  // const ingredientOptions = product.groupedOptions?.ingredient || []
-  // const variablePriceOptions = product.groupedOptions?.variable || []
   const noteOptions = product.options?.filter((option) => option.type === 'note') || []
   const limitedIngredientOptions = product.groupedOptions?.['limited-ingredient'] || []
 
-  // const hasSizeOptions = sizeOptions.length > 0
-  // const hasLimitedIngredientOptions = limitedIngredientOptions.length > 0
-  // const hasIngredientOptions = ingredientOptions.length > 0
-  // const hasVariableOptions = variablePriceOptions.length > 0
   const hasNoteOptions = noteOptions.length > 0
-
-  // const isVariableOnly = hasVariableOptions && !hasSizeOptions && !hasIngredientOptions
-  // const isFreeSelectionOnly =
-  //   hasIngredientOptions && !hasSizeOptions && !hasLimitedIngredientOptions
-
   const hasSizeOptions = sizeOptions.length > 0
   const hasLimitedIngredientOptions = limitedIngredientOptions.length > 0
 
   const sizeSelected = hasSizeOptions ? !!selectedOption : true
   const limitedIngredientSelected = hasLimitedIngredientOptions ? selectedLimitedOptionIds.length > 0 : true
 
-  // const isReadyToAdd =
-  //   isVariableOnly || isFreeSelectionOnly || (
-  //     [hasSizeOptions ? !!selectedOption : true, hasLimitedIngredientOptions ? selectedLimitedOptionIds.length > 0 : true]).every(Boolean)
-
   const isReadyToAdd = sizeSelected && limitedIngredientSelected
-
   const showQuantitySelector = isReadyToAdd
 
   return (
@@ -226,6 +204,7 @@ export default function ProductOptionsModal({ product, isOpen, onClose }: Produc
                         selectedOptionIds={selectedLimitedOptionIds}
                         setSelectedOptionIds={setSelectedLimitedOptionIds}
                         maxSelected={3}
+                        productName={product.name}
                       />
                     )
                   }

--- a/src/components/products/product-selector.tsx
+++ b/src/components/products/product-selector.tsx
@@ -1,5 +1,6 @@
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { type ProductOption } from '@/lib/types'
+import { isRefrescoNatural } from '@/lib/utils'
 
 interface ProductSelectorProps {
   options: ProductOption[]
@@ -14,13 +15,11 @@ const ProductSelector = ({
   setSelectedOptionId,
   productName
 }: ProductSelectorProps) => {
-  const isRefrescoNatural = productName === 'Refresco natural' || productName === 'Té Reca'
-
   return (
     <div className="space-y-4">
       {/* Options Select */}
       <div>
-        <h4 className="font-medium mb-2">{isRefrescoNatural ? 'Selecciona un sabor' : 'Selecciona un pan'}:</h4>
+        <h4 className="font-medium mb-2">{isRefrescoNatural(productName) ? 'Selecciona un tamaño' : 'Selecciona un pan'}:</h4>
         <Select value={selectedOptionId} onValueChange={setSelectedOptionId}>
           <SelectTrigger className="w-full">
             <SelectValue placeholder="Elige una opción..." />

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -29,3 +29,7 @@ export function formatPhoneNumber(phoneNumber: string): string {
   const formattedPhoneNumber = phoneNumber.replace(/(\d{3})(\d{3})(\d{4})/, '$1 $2 $3')
   return formattedPhoneNumber
 }
+
+// is a product a refresco natural?
+export const isRefrescoNatural = (name: string) =>
+  ['Refresco natural', 'Té Reca', 'Peñafiel'].includes(name)


### PR DESCRIPTION
Refactored drink options to use `limited-ingredient` types for flavors and separated `size` options. Introduced helper to identify refresco products and enforce single flavor selection. Updated UI components to display correct labels and prevent invalid combinations.